### PR TITLE
Fix printVersion gradle task

### DIFF
--- a/bin/build-and-submit.sh
+++ b/bin/build-and-submit.sh
@@ -3,7 +3,7 @@
 
 # Version of the jar file.
 # TODO: Extract from `build.gradle`.
-VERSION=$(./gradlew printVersion | head -1)
+VERSION=$(./gradlew printVersion | grep "ProjectVersion:" |awk '{print $2}')
 JARFILE="cratedb-flink-jobs-${VERSION}.jar"
 
 # Build job

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ archivesBaseName = 'cratedb-flink-jobs'
 version = 0.3
 
 tasks.register("printVersion") {
-    println project.version
+    println "ProjectVersion: " + project.version
 }
 
 ext {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement\

Print a distinctive line to count for any gradle output before the actual printed version and then parse it accordingly to extract the project version.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
