### PR TITLE
Use vanilla postgres - Prepare 0.5 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,15 @@ Changelog
 in progress
 ===========
 
-2023-04-27 0.4
+2023-04-04 0.5
+==============
+- Use vanilla PostgreSQL JDBC driver
+
+2023-03-27 0.4
 ==============
 - Upgrade to use Flink 1.17
 
-2023-04-23 0.3
+2023-03-23 0.3
 ==============
 - Modernize to use Flink 1.16
 

--- a/README.rst
+++ b/README.rst
@@ -124,8 +124,8 @@ JDBC drivers
   | Driver class: ``org.postgresql.Driver``
   | URL schema: ``postgresql://``
 
-- | ``TaxiRidesStreamingJob`` and ``SimpleTableApiJob`` use the `CrateDB JDBC driver`_
-  | Driver class: ``io.crate.client.jdbc.CrateDriver``
+- | ``TaxiRidesStreamingJob`` and ``SimpleTableApiJob`` use the `PostgreSQL JDBC driver`_ with CrateDB dialect
+  | Driver class: ``org.postgresql.Driver``
   | URL schema: ``crate://``
 
 
@@ -191,7 +191,6 @@ Optional settings
 .. _Build a data ingestion pipeline using Kafka, Flink, and CrateDB: https://dev.to/crate/build-a-data-ingestion-pipeline-using-kafka-flink-and-cratedb-1h5o
 .. _CrateDB: https://crate.io/
 .. _CrateDB Community Day #2: https://community.crate.io/t/cratedb-community-day-2/1415
-.. _CrateDB JDBC driver: https://crate.io/docs/jdbc/
 .. _Docker Compose: https://docs.docker.com/compose/
 .. _executable end-to-end tutorial for Apache Kafka, Apache Flink, and CrateDB: https://github.com/crate/cratedb-examples/tree/main/stacks/kafka-flink#readme
 .. _Flink DataStream API: https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/data_stream_api/

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ ext {
     flinkVersion = '1.17.0'
     jacksonVersion = '2.14.2'
     postgresJDBCVersion = '42.6.0'
-    crateJDBCVersion = '2.6.0'
     slf4jVersion = '2.0.7'
     log4jVersion = '2.20.0'
 }
@@ -67,8 +66,6 @@ dependencies {
 
     // PostgreSQL
     flinkShadowJar "org.postgresql:postgresql:${postgresJDBCVersion}"
-    // CrateDB - for the Simple*Job to be run inside IDE
-    implementation "io.crate:crate-jdbc:${crateJDBCVersion}"
 
     runtimeOnly "org.apache.flink:flink-runtime:${flinkVersion}"
     runtimeOnly "org.apache.flink:flink-table-runtime:${flinkVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 group = 'io.crate'
 archivesBaseName = 'cratedb-flink-jobs'
-version = 0.4
+version = 0.5
 
 tasks.register("printProjectVersion") {
     println "ProjectVersion: " + project.version


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- With https://github.com/apache/flink-connector-jdbc/pull/29/commits/6011f6d5a1bcb331ace195a41002a76a63ddbd99, we can use PostgreSQL vanilla JDBC driver!

- Prepare for 0.5 release

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
