### PR TITLE
Fix: Correct Kafka topic parameter handling and dependency alignment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    ignore:
+      # The Flink connectors are versioned `<connector>-<flinkline>` (e.g. 3.4.0-1.20).
+      # A major bump crosses to a new Flink line (e.g. 4.x targets Flink 2.0) and must
+      # stay aligned with `flinkVersion` in build.gradle, so require manual review for it.
+      - dependency-name: "org.apache.flink:flink-connector-kafka"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.apache.flink:flink-connector-jdbc"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ Changelog
 in progress
 ===========
 
+2026-06-09 0.7
+==============
+- Fix TaxiRidesStreamingJob Kafka source subscribing to the literal topic name
+  "kafka.topic" instead of the value of the ``--kafka.topic`` parameter; regressed
+  during the Flink 1.20 KafkaSource migration
+- Pin flink-connector-kafka to the Flink 1.20 line (3.4.0-1.20); the previous
+  4.0.1-2.0 targets Flink 2.0 and is incompatible with the 1.20.1 runtime
+
 2025-03-22 0.6
 ==============
 - Upgrade to latest flink (1.20.1)

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ tasks.register("printFlinkVersion") {
 ext {
     flinkVersion = '1.20.1'
     flinkJdbcVersion = '3.3.0-1.20'
-    flinkKafkaVersion = '4.0.1-2.0'
+    flinkKafkaVersion = '3.4.0-1.20'
     jacksonVersion = '2.21.1'
     postgresJDBCVersion = '42.7.8'
     crateJDBCVersion = '2.7.0'

--- a/src/main/java/io/crate/streaming/TaxiRidesStreamingJob.java
+++ b/src/main/java/io/crate/streaming/TaxiRidesStreamingJob.java
@@ -24,7 +24,7 @@ public class TaxiRidesStreamingJob {
         ParameterTool parameters = ParameterTool.fromArgs(args);
 
         env
-                .fromSource(createStreamSource(parameters), WatermarkStrategy.noWatermarks(), "kafa")
+                .fromSource(createStreamSource(parameters), WatermarkStrategy.noWatermarks(), "kafka")
                 .map(new TaxiRideToRowStringFunction())
                 .addSink(
                     JdbcSink.sink(
@@ -60,7 +60,7 @@ public class TaxiRidesStreamingJob {
         );
 
         return KafkaSource.<TaxiRide>builder()
-                .setTopics("kafka.topic")
+                .setTopics(parameters.getRequired("kafka.topic"))
                 .setDeserializer(TaxiRideDeserializationSchema.INSTANCE)
                 .setProperties(properties)
                 .build();


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Fixed TaxiRidesStreamingJob subscribing to the literal Kafka topic "kafka.topic" instead of using the `--kafka.topic` parameter.
- Aligned flink-connector-kafka version to 3.4.0-1.20, compatible with Flink 1.20 runtime.
- Updated Dependabot to ignore major updates for Flink connectors requiring manual review.

## Checklist

 - [x] [issue](https://github.com/crate/cratedb-examples/pull/859)
