### PR TITLE
Upgrade: Migrate to Flink 2.0.2 and Java 17

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 in progress
 ===========
 
-2026-06-09 0.8
+2026-06-10 0.8
 ==============
 - Upgrade to Flink 2.0.2 (with Java 17)
 - Migrate the JDBC connector to the Flink 2.0 split artifacts ``flink-connector-jdbc-{core,postgres,cratedb}:4.0.0-2.0`` (the monolithic ``flink-connector-jdbc`` was retired at 3.3.0-1.20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ Changelog
 in progress
 ===========
 
+2026-06-09 0.8
+==============
+- Upgrade to Flink 2.0.2 (with Java 17)
+- Migrate the JDBC connector to the Flink 2.0 split artifacts ``flink-connector-jdbc-{core,postgres,cratedb}:4.0.0-2.0`` (the monolithic ``flink-connector-jdbc`` was retired at 3.3.0-1.20)
+
+
 2026-06-09 0.7
 ==============
 - Fix TaxiRidesStreamingJob Kafka source subscribing to the literal topic name

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,9 @@ tasks.register("printFlinkVersion") {
 }
 
 ext {
-    flinkVersion = '1.20.1'
-    flinkJdbcVersion = '3.3.0-1.20'
-    flinkKafkaVersion = '3.4.0-1.20'
+    flinkVersion = '2.0.2'
+    jdbcConnectorVersion = '4.0.0-2.0'
+    flinkKafkaVersion = '4.0.1-2.0'
     jacksonVersion = '2.21.1'
     postgresJDBCVersion = '42.7.8'
     crateJDBCVersion = '2.7.0'
@@ -34,7 +34,7 @@ ext {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -49,6 +49,10 @@ configurations {
     flinkShadowJar.exclude group: 'com.google.code.findbugs', module: 'jsr305'
     flinkShadowJar.exclude group: 'org.slf4j'
     flinkShadowJar.exclude group: 'org.apache.logging.log4j'
+    // Flink 2.0's runtime ships the at.yawk.lz4 fork of lz4-java, which conflicts (same Gradle
+    // capability) with the org.lz4:lz4-java that kafka-clients pulls in. The fork keeps the same
+    // net.jpountz.lz4 classes, so drop the org.lz4 one and let Flink's fork satisfy both.
+    flinkShadowJar.exclude group: 'org.lz4', module: 'lz4-java'
 }
 
 dependencies {
@@ -57,7 +61,8 @@ dependencies {
     flinkShadowJar "org.apache.flink:flink-clients:${flinkVersion}"
     flinkShadowJar "org.apache.flink:flink-table-api-java:${flinkVersion}"
     flinkShadowJar "org.apache.flink:flink-table-api-java-bridge:${flinkVersion}"
-    flinkShadowJar "org.apache.flink:flink-connector-jdbc:${flinkJdbcVersion}"
+    flinkShadowJar "org.apache.flink:flink-connector-jdbc-core:${jdbcConnectorVersion}"
+    flinkShadowJar "org.apache.flink:flink-connector-jdbc-cratedb:${jdbcConnectorVersion}"
 
     // Kafka
     // https://mvnrepository.com/artifact/org.apache.flink

--- a/src/main/java/io/crate/flink/demo/SimpleJdbcSinkJob.java
+++ b/src/main/java/io/crate/flink/demo/SimpleJdbcSinkJob.java
@@ -2,7 +2,7 @@ package io.crate.flink.demo;
 
 import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
-import org.apache.flink.connector.jdbc.JdbcSink;
+import org.apache.flink.connector.jdbc.core.datastream.sink.JdbcSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 public class SimpleJdbcSinkJob {
@@ -34,27 +34,27 @@ public class SimpleJdbcSinkJob {
                 new Book(102L, "Streaming Systems", "Tyler Akidau, Slava Chernyak, Reuven Lax", 2018),
                 new Book(103L, "Designing Data-Intensive Applications", "Martin Kleppmann", 2017),
                 new Book(104L, "Kafka: The Definitive Guide", "Gwen Shapira, Neha Narkhede, Todd Palino", 2017)
-        ).addSink(
-                JdbcSink.sink(
-                        "insert into my_schema.books (id, title, authors, year) values (?, ?, ?, ?)",
-                        (statement, book) -> {
-                            statement.setLong(1, book.id);
-                            statement.setString(2, book.title);
-                            statement.setString(3, book.authors);
-                            statement.setInt(4, book.year);
-                        },
-                        JdbcExecutionOptions.builder()
+        ).sinkTo(
+                JdbcSink.<Book>builder()
+                        .withQueryStatement(
+                                "insert into my_schema.books (id, title, authors, year) values (?, ?, ?, ?)",
+                                (statement, book) -> {
+                                    statement.setLong(1, book.id);
+                                    statement.setString(2, book.title);
+                                    statement.setString(3, book.authors);
+                                    statement.setInt(4, book.year);
+                                })
+                        .withExecutionOptions(JdbcExecutionOptions.builder()
                                 .withBatchSize(1000)
                                 .withBatchIntervalMs(200)
                                 .withMaxRetries(5)
-                                .build(),
-                        new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+                                .build())
+                        .buildAtLeastOnce(new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
                                 .withUrl("jdbc:postgresql://localhost:5432/crate")
                                 .withDriverName("org.postgresql.Driver")
                                 .withUsername("crate")
                                 .withPassword("crate")
-                                .build()
-                ));
+                                .build()));
         env.execute();
     }
 }

--- a/src/main/java/io/crate/flink/demo/SimpleTableApiJob.java
+++ b/src/main/java/io/crate/flink/demo/SimpleTableApiJob.java
@@ -2,7 +2,7 @@ package io.crate.flink.demo;
 
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.connector.jdbc.catalog.JdbcCatalog;
+import org.apache.flink.connector.jdbc.cratedb.database.catalog.CrateDBCatalog;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
@@ -43,14 +43,13 @@ public class SimpleTableApiJob {
         String password        = "crate";
         String baseUrl         = "jdbc:crate://localhost:5432";
 
-        JdbcCatalog catalog = new JdbcCatalog(
+        CrateDBCatalog catalog = new CrateDBCatalog(
                 Thread.currentThread().getContextClassLoader(),
                 CATALOG_NAME,
                 defaultDatabase,
                 username,
                 password,
-                baseUrl,
-                null
+                baseUrl
                 );
         streamTableEnv.registerCatalog(CATALOG_NAME, catalog);
         batchTableEnv.registerCatalog(CATALOG_NAME, catalog);

--- a/src/main/java/io/crate/streaming/TaxiRideToRowStringFunction.java
+++ b/src/main/java/io/crate/streaming/TaxiRideToRowStringFunction.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import io.crate.streaming.model.TaxiRide;
+import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.types.Row;
 
@@ -14,8 +14,8 @@ public class TaxiRideToRowStringFunction extends RichMapFunction<TaxiRide, Row> 
     private volatile ObjectMapper mapper;
 
     @Override
-    public void open(Configuration parameters) throws Exception {
-        super.open(parameters);
+    public void open(OpenContext openContext) throws Exception {
+        super.open(openContext);
         mapper = new ObjectMapper();
         mapper.setDateFormat(new ISO8601DateFormat());
     }

--- a/src/main/java/io/crate/streaming/TaxiRidesStreamingJob.java
+++ b/src/main/java/io/crate/streaming/TaxiRidesStreamingJob.java
@@ -4,12 +4,13 @@ import io.crate.streaming.model.TaxiRide;
 import io.crate.streaming.model.TaxiRideDeserializationSchema;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
-import org.apache.flink.connector.jdbc.JdbcSink;
+import org.apache.flink.connector.jdbc.core.datastream.sink.JdbcSink;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.ParameterTool;
 
 import java.util.Properties;
 
@@ -26,22 +27,22 @@ public class TaxiRidesStreamingJob {
         env
                 .fromSource(createStreamSource(parameters), WatermarkStrategy.noWatermarks(), "kafka")
                 .map(new TaxiRideToRowStringFunction())
-                .addSink(
-                    JdbcSink.sink(
-                            String.format("INSERT INTO doc.%s (payload) VALUES (?)", parameters.getRequired("crate.table")),
-                            (statement, row) -> statement.setString(1, (String) row.getField(0)),
-                            JdbcExecutionOptions.builder()
+                .sinkTo(
+                    JdbcSink.<Row>builder()
+                            .withQueryStatement(
+                                    String.format("INSERT INTO doc.%s (payload) VALUES (?)", parameters.getRequired("crate.table")),
+                                    (statement, row) -> statement.setString(1, (String) row.getField(0)))
+                            .withExecutionOptions(JdbcExecutionOptions.builder()
                                     .withBatchSize(1000)
                                     .withBatchIntervalMs(200)
                                     .withMaxRetries(5)
-                                    .build(),
-                            new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+                                    .build())
+                            .buildAtLeastOnce(new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
                                     .withUrl(String.format("jdbc:postgresql://%s/", parameters.getRequired("crate.hosts")))
                                     .withDriverName("org.postgresql.Driver")
                                     .withUsername(parameters.get("crate.user", "crate"))
                                     .withPassword(parameters.get("crate.password", ""))
-                                    .build()
-                    ));
+                                    .build()));
 
         env.execute();
     }


### PR DESCRIPTION
- Upgraded Flink version to 2.0.2, transitioning to Java 17.
- Migrated from monolithic `flink-connector-jdbc` artifact to Flink 2.0 split `flink-connector-jdbc-*` artifacts.
- Replaced `JdbcCatalog` with `CrateDBCatalog` for improved compatibility with CrateDB.
- Refactored sink operations to use new Flink 2.0 sink APIs.
- Resolved dependency conflicts with Flink's `lz4-java` runtime fork.

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
